### PR TITLE
update mobile cheat codes

### DIFF
--- a/cheat-codes.md
+++ b/cheat-codes.md
@@ -28,13 +28,13 @@ This document lists all available cheat codes in Phil's Escape. Cheat codes can 
 | Platform | Input |
 |----------|-------|
 | **Keyboard** | `D` `R` `U` `M` (type quickly) |
-| **Mobile/Touch** | ▶ ▶ ▶ ▲ ▲ ▲ |
+| **Mobile/Touch** | 🛡 🛡 🛡 ▲ ▲ ▲ |
 
 **Notes:**
 - Each button press must be entered within **1.4 seconds** of the previous one, or the code resets
 - Cannot be used during the final boss fight
 - Text popup will show `LEVEL X`, `WORLD X`, or `FINAL BOSS` when activated
-- For mobile: Right button is ▶, Jump button is ▲
+- For mobile: Shield button is 🛡, Jump button is ▲
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@ const SFX = {
 // ══════════════════════════════════════════════════════
 const keys={}, touches={L:false,R:false,J:false,A:false,S:false,start:false};
 const isTouchDevice='ontouchstart' in window;
-const WORLD_CHEAT='xavier', MOBILE_WORLD_CHEAT='jjsjjsjjs', LEVEL_CHEAT='drum', MOBILE_LEVEL_CHEAT='rrrjjj', WORLD_CHEAT_TIMEOUT=1400;
+const WORLD_CHEAT='xavier', MOBILE_WORLD_CHEAT='jjsjjsjjs', LEVEL_CHEAT='drum', MOBILE_LEVEL_CHEAT='sssjjj', WORLD_CHEAT_TIMEOUT=1400;
 let worldCheatBuffer='', mobileWorldCheatBuffer='', worldCheatLastAt=0;
 let levelCheatBuffer='', mobileLevelCheatBuffer='', levelCheatLastAt=0;
 function resetWorldCheat(){ worldCheatBuffer=''; mobileWorldCheatBuffer=''; worldCheatLastAt=0; }


### PR DESCRIPTION
This pull request updates the cheat code for unlocking levels on mobile/touch devices in both the documentation and the game logic to use the shield button (🛡) instead of the right button (▶). This ensures consistency between the documentation and the actual code, and clarifies the instructions for mobile users.

Cheat code update:

* Changed the mobile/touch level unlock cheat code sequence from using the right button (▶) to the shield button (🛡) in both the `cheat-codes.md` documentation and the `index.html` game logic (`MOBILE_LEVEL_CHEAT` is now `sssjjj`). [[1]](diffhunk://#diff-ea413c5a077686b8f4cafbf34d7132354cdcd6fc1cf93ab2d8a3cb9712d11875L31-R37) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L92-R92)

Documentation clarification:

* Updated the notes in `cheat-codes.md` to specify that the shield button (🛡) is now used for the mobile cheat code, replacing the previous reference to the right button (▶).